### PR TITLE
Add ppc64el and s390x architectures

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,8 +7,14 @@ description: |
   Exporter that exposes information gathered from OpenVswitch for use by the Prometheus monitoring system
 confinement: strict
 architectures:
-  - amd64
-  - arm64
+  - build-on: amd64
+    run-on: amd64
+  - build-on: arm64
+    run-on: arm64
+  - build-on: ppc64el
+    run-on: ppc64el
+  - build-on: s390x
+    run-on: s390x
 parts:
   ovs-exporter:
     plugin: go


### PR DESCRIPTION
Add ppc64el and s390x to the list of architecture to build the snap on.

This change uses 'build-on' and 'run-on', because otherwise 'snapcraft remote-build' builds a single snap that's multi-arch (e.g. prometheus-ovn-exporter_1.0.3_multi.snap)

Signed-off-by: Felipe Reyes <felipe.reyes@canonical.com>