### PR TITLE
Update to upstream version 1.0.7

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: prometheus-ovs-exporter
-version: 1.0.5
+version: 1.0.7
 base: core20
 grade: stable
 summary: Prometheus OpenVswitch Exporter
@@ -18,9 +18,9 @@ architectures:
 parts:
   ovs-exporter:
     plugin: go
-    go-channel: 1.19/stable
+    go-channel: 1.20/stable
     source: https://github.com/greenpau/ovs_exporter.git
-    source-tag: v1.0.5
+    source-tag: v1.0.7
     build-packages:
       - gcc
       - golang-go


### PR DESCRIPTION
Update to the latest upstream version
- Bump the upstream version from 1.0.5 to 1.0.7
- Bump the golang channel from 1.19 to 1.20

This adds a few minor fixes, the rx_multicast_packets metric and
upgrades a few dependencies.

Signed-off-by: Trent Lloyd <trent.lloyd@canonical.com>
